### PR TITLE
fix: repair release workflow contracts

### DIFF
--- a/.github/workflow-templates/prepare-release.yml
+++ b/.github/workflow-templates/prepare-release.yml
@@ -60,7 +60,7 @@ jobs:
 
       # Whether to install virtual display for testing. Set to true if tests 
       # are invoking graphical elements (i.e showing figures etc.)
-      needs_virtual_display
+      needs_virtual_display: false
       
     secrets:
       # SSH deploy key for pushing to protected branches. Required for creating

--- a/.github/workflows/examples/custom-release-with-virtual-display.yml
+++ b/.github/workflows/examples/custom-release-with-virtual-display.yml
@@ -23,7 +23,7 @@ jobs:
   # Use the standard matrix building job
   configure_test_matrix:
     name: Build release test matrix
-    uses: ./.github/workflows/create-matrix-job.yml.yml
+    uses: ./.github/workflows/create-matrix-job.yml
     with:
       needs_python: true
 

--- a/.github/workflows/validate-version-job.yml
+++ b/.github/workflows/validate-version-job.yml
@@ -15,6 +15,9 @@ on:
       version_number:
         description: 'Validated version number'
         value: ${{ jobs.validate_version.outputs.version_number }}
+      skip_workflow:
+        description: 'Whether to skip the workflow'
+        value: ${{ jobs.validate_version.outputs.skip_workflow }}
 
 jobs:
   validate_version:
@@ -22,7 +25,13 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       version_number: ${{ steps.validate.outputs.version_number }}
+      skip_workflow: ${{ steps.validate.outputs.skip_workflow }}
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
       - name: Validate version
         id: validate
         uses: ehennestad/matbox-actions/validate-version@v1


### PR DESCRIPTION
## Summary
- Forward the validate-version skip_workflow output through the reusable validation workflow.
- Pass each MATLAB matrix release as the test report subdirectory so report artifacts retain release-specific layout.
- Fix invalid workflow references and YAML in release workflow examples/templates.