### PR TITLE
ci: add workflow validation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -128,7 +128,7 @@ jobs:
       ref_name: ${{ github.ref_name }}
 
   configure_test_matrix:
-    uses: ./.github/workflows/create-matrix-job.yml.yml
+    uses: ./.github/workflows/create-matrix-job.yml
     with:
       needs_python: true
 
@@ -197,4 +197,3 @@ jobs:
       
       # Continue with standard steps...
 ```
-

--- a/.github/workflows/codespell-workflow.yml
+++ b/.github/workflows/codespell-workflow.yml
@@ -35,8 +35,8 @@ jobs:
           ignore_words=$(grep -E '^ignore-words-list' "$CONFIG_FILE" | sed 's/^ignore-words-list *= *//')
           
           # Export values as environment variables
-          echo "SKIP=$skip" >> $GITHUB_ENV
-          echo "IGNORE_WORDS_LIST=$ignore_words" >> $GITHUB_ENV
+          echo "SKIP=$skip" >> "$GITHUB_ENV"
+          echo "IGNORE_WORDS_LIST=$ignore_words" >> "$GITHUB_ENV"
 
       - name: Codespell
         uses: codespell-project/actions-codespell@v2

--- a/.github/workflows/examples/custom-release-with-virtual-display.yml
+++ b/.github/workflows/examples/custom-release-with-virtual-display.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y xvfb
-          echo "DISPLAY=:99.0" >> $GITHUB_ENV
+          echo "DISPLAY=:99.0" >> "$GITHUB_ENV"
           Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           sleep 3
 

--- a/.github/workflows/run-test-matrix-job.yml
+++ b/.github/workflows/run-test-matrix-job.yml
@@ -57,7 +57,7 @@ jobs:
         run: |
           sudo apt-get install -y xvfb
           Xvfb :99 &
-          echo "DISPLAY=:99" >> $GITHUB_ENV
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
 
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v3

--- a/.github/workflows/test-code-workflow.yml
+++ b/.github/workflows/test-code-workflow.yml
@@ -69,7 +69,7 @@ jobs:
         run: |
           sudo apt-get install -y xvfb
           Xvfb :99 &
-          echo "DISPLAY=:99" >> $GITHUB_ENV
+          echo "DISPLAY=:99" >> "$GITHUB_ENV"
 
       - name: Set up MATLAB (${{ inputs.matlab_release }})
         uses: matlab-actions/setup-matlab@v3

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -4,14 +4,14 @@ on:
   push:
     branches: [ main ]
     paths:
-      - '.github/workflows/**'
-      - '.github/workflow-templates/**'
+      - '.github/workflows/**/*.yml'
+      - '.github/workflow-templates/*.yml'
       - '*/action.yml'
   pull_request:
     branches: [ main ]
     paths:
-      - '.github/workflows/**'
-      - '.github/workflow-templates/**'
+      - '.github/workflows/**/*.yml'
+      - '.github/workflow-templates/*.yml'
       - '*/action.yml'
   workflow_dispatch:
 

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -1,0 +1,67 @@
+name: Validate workflows
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/**'
+      - '.github/workflow-templates/**'
+      - '*/action.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/**'
+      - '.github/workflow-templates/**'
+      - '*/action.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate_yaml:
+    name: Validate YAML syntax
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Parse workflow and action YAML
+        shell: bash
+        run: |
+          ruby -e '
+            require "psych"
+
+            files = Dir[
+              ".github/workflows/**/*.yml",
+              ".github/workflow-templates/*.yml",
+              "*/action.yml"
+            ]
+
+            abort("No YAML files found") if files.empty?
+
+            files.each do |file|
+              Psych.parse_file(file)
+              puts "ok #{file}"
+            end
+          '
+
+  actionlint:
+    name: Run actionlint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Check GitHub workflows
+        shell: bash
+        run: |
+          mapfile -t workflow_files < <(find .github/workflows -name '*.yml' -print)
+          go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color "${workflow_files[@]}"

--- a/.github/workflows/validate-workflows.yml
+++ b/.github/workflows/validate-workflows.yml
@@ -60,8 +60,8 @@ jobs:
         with:
           go-version: stable
 
-      - name: Check GitHub workflows
+      - name: Check GitHub workflows and templates
         shell: bash
         run: |
-          mapfile -t workflow_files < <(find .github/workflows -name '*.yml' -print)
-          go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color "${workflow_files[@]}"
+          mapfile -t actionlint_files < <(find .github/workflows .github/workflow-templates -name '*.yml' -print)
+          go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 -color "${actionlint_files[@]}"


### PR DESCRIPTION
## Summary
- Add a workflow validation CI job for workflow, workflow-template, and composite-action YAML.
- Run actionlint against GitHub workflow files using the pinned v1.7.12 downloader.
- Fix the stale create-matrix reusable workflow reference in the workflows README.