### PR TITLE
ci: improve badge and tag shell checks

### DIFF
--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -37,7 +37,7 @@ runs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         # Delete the existing tag locally if it exists
-        if git tag -l "v${{ inputs.version_number }}" | grep -q "v${{ inputs.version_number }}"; then
+        if git tag -l "v${{ inputs.version_number }}" | grep -Fxq "v${{ inputs.version_number }}"; then
           echo "Deleting existing local tag v${{ inputs.version_number }}"
           git tag -d "v${{ inputs.version_number }}"
         else
@@ -45,7 +45,7 @@ runs:
         fi
         
         # Delete the existing tag remotely if it exists
-        if git ls-remote --tags origin | grep -q "refs/tags/v${{ inputs.version_number }}"; then
+        if git ls-remote --tags origin | grep -Fq "refs/tags/v${{ inputs.version_number }}"; then
           echo "Deleting existing remote tag v${{ inputs.version_number }}"
           git push origin --delete "v${{ inputs.version_number }}"
         else

--- a/generate-tested-with-badge/action.yml
+++ b/generate-tested-with-badge/action.yml
@@ -48,7 +48,7 @@ runs:
       id: check_branch
       shell: bash
       run: |
-        if git ls-remote --heads origin gh-badges | grep -q gh-badges; then
+        if git ls-remote --heads origin gh-badges | grep -Fq "refs/heads/gh-badges"; then
           echo "branch_exists=true" >> $GITHUB_OUTPUT
           echo "gh-badges branch exists"
         else
@@ -94,8 +94,8 @@ runs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
         # Only proceed with commit and push if changes are detected
-        if [[ $(git add .github/badges/* --dry-run | wc -l) -gt 0 ]]; then
-          git add .github/badges/*
+        git add .github/badges
+        if ! git diff --cached --quiet -- .github/badges; then
           git commit -m "Update tested with badge for release"
           git push origin gh-badges
         else

--- a/push-badges/action.yml
+++ b/push-badges/action.yml
@@ -24,7 +24,14 @@ runs:
     - name: Copy badges to PR branch
       shell: bash
       run: |
-        cp -r .github/badges/* pr-branch/.github/badges/ 2>/dev/null || echo "No badges to copy"
+        shopt -s nullglob
+        badges=(.github/badges/*)
+        mkdir -p pr-branch/.github/badges
+        if ((${#badges[@]})); then
+          cp -r "${badges[@]}" pr-branch/.github/badges/
+        else
+          echo "No badges to copy"
+        fi
 
     # Commit updated SVG badges for the issues and tests (if changed)
     - name: Commit and push SVG badges if updated
@@ -35,8 +42,13 @@ runs:
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
         git fetch 
 
-        if [[ $(git add .github/badges/* --dry-run | wc -l) -gt 0 ]]; then
-          git add .github/badges
+        if [ ! -d .github/badges ]; then
+          echo "Nothing to commit"
+          exit 0
+        fi
+
+        git add .github/badges
+        if ! git diff --cached --quiet -- .github/badges; then
           git commit -m "Update GitHub badges [skip ci]"
           git push origin HEAD
         else


### PR DESCRIPTION
## Summary
- Use fixed-string grep for release tag and gh-badges branch existence checks.
- Make badge copying handle an empty badge directory explicitly.
- Use staged diff checks instead of counting git add --dry-run output before committing badge updates.