### PR TITLE
feat: render SVG badges from MatBox badge JSON with badge-maker

### DIFF
--- a/check-code/action.yml
+++ b/check-code/action.yml
@@ -35,6 +35,30 @@ runs:
               "CreateBadge", ${{ inputs.create_badge }});
           end
 
+    # MatBox writes badge descriptions as JSON files; render them to SVG with
+    # badge-maker (the shields.io reference implementation). Older MatBox
+    # versions write SVG badges directly, in which case no JSON exists and
+    # this step does nothing.
+    - name: Render SVG badges from badge JSON files
+      if: ${{ always() && inputs.create_badge == 'true' }}
+      shell: bash
+      run: |
+        shopt -s nullglob
+        badgeJsonFiles=(docs/reports/badges/*.json)
+        if [ ${#badgeJsonFiles[@]} -eq 0 ]; then
+          echo "No badge JSON files found; nothing to render."
+          exit 0
+        fi
+        mkdir -p .github/badges
+        for jsonFile in "${badgeJsonFiles[@]}"; do
+          name=$(basename "$jsonFile" .json)
+          label=$(jq -r '.label' "$jsonFile")
+          message=$(jq -r '.message' "$jsonFile")
+          color=$(jq -r '.color' "$jsonFile")
+          npx --yes --package badge-maker badge "$label" "$message" ":$color" > ".github/badges/${name}.svg"
+          echo "Rendered .github/badges/${name}.svg"
+        done
+
     - name: Upload SARIF file
       uses: github/codeql-action/upload-sarif@v3
       continue-on-error: true # Will fail for MATLAB release < R2023a

--- a/check-code/action.yml
+++ b/check-code/action.yml
@@ -23,6 +23,11 @@ runs:
     - name: Check for MATLAB code issues
       uses: matlab-actions/run-command@v3
       if: always()
+      env:
+        # Ask MatBox to write badge JSON (rendered to SVG below) instead of
+        # rendering SVG in MATLAB via pybadges. Ignored by older MatBox
+        # versions, which write SVG directly.
+        MATBOX_BADGE_FORMAT: json
       with:
         command: |
           addpath(genpath("${{ inputs.tools_directory }}"));

--- a/test-code/action.yml
+++ b/test-code/action.yml
@@ -45,6 +45,30 @@ runs:
             matbox.tasks.testToolbox(pwd, testToolboxArgs{:});
           end
 
+    # MatBox writes badge descriptions as JSON files; render them to SVG with
+    # badge-maker (the shields.io reference implementation). Older MatBox
+    # versions write SVG badges directly, in which case no JSON exists and
+    # this step does nothing.
+    - name: Render SVG badges from badge JSON files
+      if: ${{ always() && inputs.create_badge == 'true' }}
+      shell: bash
+      run: |
+        shopt -s nullglob
+        badgeJsonFiles=(docs/reports/badges/*.json)
+        if [ ${#badgeJsonFiles[@]} -eq 0 ]; then
+          echo "No badge JSON files found; nothing to render."
+          exit 0
+        fi
+        mkdir -p .github/badges
+        for jsonFile in "${badgeJsonFiles[@]}"; do
+          name=$(basename "$jsonFile" .json)
+          label=$(jq -r '.label' "$jsonFile")
+          message=$(jq -r '.message' "$jsonFile")
+          color=$(jq -r '.color' "$jsonFile")
+          npx --yes --package badge-maker badge "$label" "$message" ":$color" > ".github/badges/${name}.svg"
+          echo "Rendered .github/badges/${name}.svg"
+        done
+
     - name: Publish test results
       uses: EnricoMi/publish-unit-test-result-action@v2
       if: always()

--- a/test-code/action.yml
+++ b/test-code/action.yml
@@ -26,6 +26,11 @@ runs:
     - name: Run MATLAB test suites
       uses: matlab-actions/run-command@v3
       if: always()
+      env:
+        # Ask MatBox to write badge JSON (rendered to SVG below) instead of
+        # rendering SVG in MATLAB via pybadges. Ignored by older MatBox
+        # versions, which write SVG directly.
+        MATBOX_BADGE_FORMAT: json
       with:
         command: |
           addpath(genpath("${{ inputs.source_directory }}"));


### PR DESCRIPTION
## Summary

Companion to ehennestad/MatBox#62, which removes the deprecated `pybadges` Python dependency. Badge rendering moves out of MATLAB:

- The `check-code` and `test-code` actions set `MATBOX_BADGE_FORMAT=json` on their MATLAB steps, asking MatBox to write badge descriptions as JSON files (`docs/reports/badges/*.json`) instead of rendering SVG in MATLAB via pybadges
- A new "Render SVG badges" step converts each JSON file to `.github/badges/<name>.svg` using [badge-maker](https://www.npmjs.com/package/badge-maker) — the shields.io reference implementation (CC0), run locally via `npx` with no external service call. Node and `jq` are preinstalled on GitHub-hosted runners
- The render step is guarded by the existing `create_badge` input and no-ops when no badge JSON exists

## Compatibility

The env-variable handshake makes every version combination safe, so merge order does not matter:

- new actions + new MatBox → JSON written, rendered by badge-maker
- new actions + old MatBox → variable ignored, SVG written directly by pybadges, render step no-ops
- old/pinned actions + new MatBox → variable absent, MatBox falls back to the pybadges SVG path

Expect a one-time badge-churn commit in downstream repositories on first run with both changes, since badge-maker's SVG markup differs slightly from pybadges' output (visually equivalent flat style).

🤖 Generated with [Claude Code](https://claude.com/claude-code)