### PR TITLE
feat: default to release installs and support pinning a MatBox version

### DIFF
--- a/.github/workflows/check-code-workflow.yml
+++ b/.github/workflows/check-code-workflow.yml
@@ -3,6 +3,10 @@ name: Analyse code
 on:
   workflow_call:
     inputs:
+      matbox_version:
+        description: MatBox version to install ("latest" or a specific version like "0.9.10").
+        type: string
+        default: 'latest'
       source_directory:
         description: Path to the directory containing code. Code analysis will run on the contents of this folder and its subfolders.
         type: string
@@ -50,6 +54,8 @@ jobs:
 
       - name: Install MatBox
         uses: ehennestad/matbox-actions/install-matbox@v1
+        with:
+          version: ${{ inputs.matbox_version }}
 
       - name: Check code and upload report
         uses: ehennestad/matbox-actions/check-code@v1

--- a/.github/workflows/package-toolbox-job.yml
+++ b/.github/workflows/package-toolbox-job.yml
@@ -3,6 +3,10 @@ name: Package toolbox
 on:
   workflow_call:
     inputs:
+      matbox_version:
+        description: MatBox version to install ("latest" or a specific version like "0.9.10").
+        type: string
+        default: 'latest'
       version_number:
         type: string
         required: true
@@ -45,6 +49,8 @@ jobs:
 
       - name: Install MatBox
         uses: ehennestad/matbox-actions/install-matbox@v1
+        with:
+          version: ${{ inputs.matbox_version }}
 
       # Generate badge
       - name: Generate "tested with" badge

--- a/.github/workflows/prepare-release-workflow.yml
+++ b/.github/workflows/prepare-release-workflow.yml
@@ -3,6 +3,10 @@ name: Prepare toolbox release
 on:
   workflow_call:
     inputs:
+      matbox_version:
+        description: MatBox version to install ("latest" or a specific version like "0.9.10").
+        type: string
+        default: 'latest'
       version:
         type: string
         required: false
@@ -73,6 +77,7 @@ jobs:
     if: needs.validate_version.outputs.skip_workflow != 'true'
     uses: ehennestad/matbox-actions/.github/workflows/run-test-matrix-job.yml@v1
     with:
+      matbox_version: ${{ inputs.matbox_version }}
       source_directory: ${{ inputs.source_directory }}
       tests_directory: ${{ inputs.tests_directory }}
       tools_directory: ${{ inputs.tools_directory }}
@@ -87,6 +92,7 @@ jobs:
     if: needs.validate_version.outputs.skip_workflow != 'true'
     uses: ehennestad/matbox-actions/.github/workflows/package-toolbox-job.yml@v1
     with:
+      matbox_version: ${{ inputs.matbox_version }}
       version_number: ${{ needs.validate_version.outputs.version_number }}
       source_directory: ${{ inputs.source_directory }}
       tools_directory: ${{ inputs.tools_directory }}
@@ -99,5 +105,6 @@ jobs:
     if: needs.validate_version.outputs.skip_workflow != 'true'
     uses: ehennestad/matbox-actions/.github/workflows/verify-installation-job.yml@v1
     with:
+      matbox_version: ${{ inputs.matbox_version }}
       toolbox_name: ${{ needs.release.outputs.toolbox_name }}
       tools_directory: ${{ inputs.tools_directory }}

--- a/.github/workflows/run-test-matrix-job.yml
+++ b/.github/workflows/run-test-matrix-job.yml
@@ -3,6 +3,10 @@ name: Run tests
 on:
   workflow_call:
     inputs:
+      matbox_version:
+        description: MatBox version to install ("latest" or a specific version like "0.9.10").
+        type: string
+        default: 'latest'
       source_directory:
         type: string
         default: 'src'
@@ -67,6 +71,8 @@ jobs:
 
       - name: Install MatBox
         uses: ehennestad/matbox-actions/install-matbox@v1
+        with:
+          version: ${{ inputs.matbox_version }}
 
       # Run all tests in the project.  Put results in a version specific subdirectory
       - name: Run tests

--- a/.github/workflows/test-code-workflow.yml
+++ b/.github/workflows/test-code-workflow.yml
@@ -3,6 +3,10 @@ name: Run tests
 on:
   workflow_call:
     inputs:
+      matbox_version:
+        description: MatBox version to install ("latest" or a specific version like "0.9.10").
+        type: string
+        default: 'latest'
       source_directory:
         description: Path to the directory containing code. Code coverage and code analysis will run on the contents of this folder and its subfolders.
         type: string
@@ -80,6 +84,8 @@ jobs:
 
       - name: Install MatBox
         uses: ehennestad/matbox-actions/install-matbox@v1
+        with:
+          version: ${{ inputs.matbox_version }}
 
       - name: Check code and upload report
         uses: ehennestad/matbox-actions/check-code@v1

--- a/.github/workflows/verify-installation-job.yml
+++ b/.github/workflows/verify-installation-job.yml
@@ -3,6 +3,10 @@ name: Verify toolbox installation
 on:
   workflow_call:
     inputs:
+      matbox_version:
+        description: MatBox version to install ("latest" or a specific version like "0.9.10").
+        type: string
+        default: 'latest'
       toolbox_name:
         type: string
         required: true
@@ -31,6 +35,8 @@ jobs:
 
       - name: Install MatBox
         uses: ehennestad/matbox-actions/install-matbox@v1
+        with:
+          version: ${{ inputs.matbox_version }}
 
       - name: Download packaged toolbox
         uses: actions/download-artifact@v7

--- a/install-matbox/action.yml
+++ b/install-matbox/action.yml
@@ -1,10 +1,14 @@
 name: 'Install MatBox'
 description: 'Install MatBox in MATLAB on GitHub runner'
 inputs:
-  mode:  # mode of installation: release or commit, i.e install latest released version or use latest commit
+  mode:  # mode of installation: release or commit, i.e install a released version or use latest commit
     description: 'Which installation mode to use'
     required: true
-    default: 'commit'
+    default: 'release'
+  version:
+    description: 'MatBox version to install, e.g. "0.9.10". Only applies to release mode.'
+    required: false
+    default: 'latest'
 runs:
   using: "composite"
   steps:
@@ -15,7 +19,7 @@ runs:
         with:
           command: |
             addpath( "${{ github.action_path }}" )
-            installMatBox( "${{ inputs.mode }}", "${{ runner.temp }}/matbox" )
+            installMatBox( "${{ inputs.mode }}", "${{ runner.temp }}/matbox", "Version", "${{ inputs.version }}" )
       
       - name: Confirm installation of MatBox
         uses: matlab-actions/run-command@v3

--- a/install-matbox/installMatBox.m
+++ b/install-matbox/installMatBox.m
@@ -1,14 +1,31 @@
-function [installPath, installMethod] = installMatBox(mode, installationFolder)
-% installMatBox - Install MatBox from latest release or latest commit
+function [installPath, installMethod] = installMatBox(mode, installationFolder, options)
+% installMatBox - Install MatBox from a release or from the latest commit
+%
+%   installMatBox() installs the latest released version of MatBox.
+%
+%   installMatBox("commit") installs MatBox from the latest commit on the
+%   main branch.
+%
+%   installMatBox("release", installationFolder, "Version", "0.9.10")
+%   installs a specific released version. Version only applies to release
+%   mode.
 
     arguments
         mode (1,1) string {mustBeMember(mode, ["release", "commit"])} = "release"
         installationFolder (1,1) string = fullfile(userpath, "Add-Ons")
+        options.Version (1,1) string = "latest"
     end
-    
+
+    % Normalize version (accept both "0.9.10" and "v0.9.10")
+    version = erase(options.Version, textBoundary("start") + "v");
+
     if mode == "release"
-        [installPath, installMethod] = installFromRelease(); % local function
+        [installPath, installMethod] = installFromRelease(version); % local function
     elseif mode == "commit"
+        if version ~= "latest"
+            warning("MatBox:Install:VersionIgnored", ...
+                "The Version option only applies to release mode and will be ignored.")
+        end
         [installPath, installMethod] = installFromCommit(installationFolder); % local function
     end
 
@@ -19,48 +36,71 @@ function [installPath, installMethod] = installMatBox(mode, installationFolder)
     end
 end
 
-function [installPath, installMethod] = installFromRelease()
+function [installPath, installMethod] = installFromRelease(version)
     addonsTable = matlab.addons.installedAddons();
     isMatchedAddon = addonsTable.Name == "MatBox";
 
+    % Reuse an installed MatBox addon when no specific version is requested,
+    % or when the installed version matches the requested one.
     if ~isempty(isMatchedAddon) && any(isMatchedAddon)
-        matlab.addons.enableAddon('MatBox')
-        rehash()
-        installPath = getMatBoxInstallPath();
-        installMethod = "mltbx";
-    else
-        info = webread('https://api.github.com/repos/ehennestad/MatBox/releases/latest');
-        assetNames = {info.assets.name};
-        isMltbx = startsWith(assetNames, 'MatBox');
-    
-        mltbx_URL = info.assets(isMltbx).browser_download_url;
-        
-        % Download matbox
-        tempFilePath = websave(tempname, mltbx_URL);
-        cleanupObj = onCleanup(@(fp) delete(tempFilePath));
-        
-        % Install toolbox
-        matlab.addons.install(tempFilePath);
-        rehash()
-        installPath = getMatBoxInstallPath();
-        installMethod = "mltbx";
+        installedVersion = addonsTable.Version(find(isMatchedAddon, 1));
+        if version == "latest" || installedVersion == version
+            matlab.addons.enableAddon('MatBox')
+            rehash()
+            installPath = getMatBoxInstallPath();
+            installMethod = "mltbx";
+            return
+        end
     end
+
+    if version == "latest"
+        releaseApiUrl = "https://api.github.com/repos/ehennestad/MatBox/releases/latest";
+    else
+        releaseApiUrl = "https://api.github.com/repos/ehennestad/MatBox/releases/tags/v" + version;
+    end
+
+    try
+        info = webread(releaseApiUrl);
+    catch ME
+        if version ~= "latest"
+            error("MatBox:Install:ReleaseNotFound", ...
+                "MatBox release v%s was not found. Check available releases at %s", ...
+                version, "https://github.com/ehennestad/MatBox/releases")
+        else
+            rethrow(ME)
+        end
+    end
+
+    assetNames = {info.assets.name};
+    isMltbx = startsWith(assetNames, 'MatBox');
+
+    mltbx_URL = info.assets(isMltbx).browser_download_url;
+
+    % Download matbox
+    tempFilePath = websave(tempname, mltbx_URL);
+    cleanupObj = onCleanup(@(fp) delete(tempFilePath));
+
+    % Install toolbox
+    matlab.addons.install(tempFilePath);
+    rehash()
+    installPath = getMatBoxInstallPath();
+    installMethod = "mltbx";
 end
 
 function [installPath, installMethod] = installFromCommit(installationFolder)
-    
+
     % Download latest zipped version of repo
     url = "https://github.com/ehennestad/MatBox/archive/refs/heads/main.zip";
     tempFilePath = websave(tempname, url);
     cleanupObj = onCleanup(@(fp) delete(tempFilePath));
-    
+
     % Unzip in temporary location
     unzippedFiles = unzip(tempFilePath, tempdir);
     unzippedFolder = unzippedFiles{1};
     if endsWith(unzippedFolder, filesep)
         unzippedFolder = unzippedFolder(1:end-1);
     end
-    
+
     % Move to installation location
     [~, repoFolderName] = fileparts(unzippedFolder);
     targetFolder = fullfile(installationFolder, repoFolderName);
@@ -70,7 +110,7 @@ function [installPath, installMethod] = installFromCommit(installationFolder)
     % Add to MATLAB's search path. Important: Only add code folder
     addpath(genpath(fullfile(targetFolder, 'code')))
     savepath()
-    
+
     % Assign outputs
     installPath = targetFolder;
     installMethod = "folder";


### PR DESCRIPTION
## Summary

`install-matbox` defaulted to installing the latest **commit** of MatBox main, so every merge to MatBox was an instant, ungated deploy to all consumers — with no way to pin or roll back (the gap surfaced while reviewing #8).

- **`mode` now defaults to `release`.** MatBox releases become the propagation gate; merging to MatBox main no longer changes consumer behavior. `commit` mode remains available for development and sandbox use.
- **New `version` input** (default `latest`): installs a specific release via the `releases/tags` API, e.g. `version: 0.9.10` (accepts `v0.9.10` too). Gives downstream repositories reproducible CI and an immediate rollback lever if a release misbehaves. A missing release fails with a clear `MatBox:Install:ReleaseNotFound` error. Only applies to release mode (warns otherwise).
- **Reusable workflows** (`test-code-workflow`, `check-code-workflow`, `run-test-matrix-job`, `package-toolbox-job`, `verify-installation-job`) gain a `matbox_version` passthrough input; `prepare-release-workflow` forwards it to its test/package/verify jobs.
- An already-installed MatBox addon is reused only when no specific version is requested or the installed version matches; otherwise the requested version is installed.

Verified: version normalization and both API endpoints (pinned tag resolves to the `.mltbx` asset; bogus version 404s into the error path) checked against the live GitHub API; all workflow YAML parses.

## Note for rollout

Once this lands and `v1` moves, consumers switch from commit-MatBox to **latest-release** MatBox — currently v0.9.10, which predates the recently merged changes (root-file packaging #61, third-party notices #60). Cut a new MatBox release around the same time so those reach consumers. The badge changes in #8 / ehennestad/MatBox#62 are version-handshaked and safe in any combination.

🤖 Generated with [Claude Code](https://claude.com/claude-code)