### PR TITLE
fix: authenticate installer API calls and harden release safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Setup MATLAB
-        uses: matlab-actions/setup-matlab@v2
+        uses: matlab-actions/setup-matlab@v3
           
       - name: Install MatBox
         uses: ehennestad/matbox-actions/install-matbox@v1
@@ -81,6 +81,19 @@ jobs:
       - name: Check Code Quality
         uses: ehennestad/matbox-actions/check-code@v1
 ```
+
+### 3. Required Permissions
+
+The calling workflow must grant the permissions used by the steps it runs:
+
+| Permission | Needed for |
+|------------|------------|
+| `contents: read` | Checking out the repository |
+| `security-events: write` | Uploading the code-analysis SARIF report (`check-code`) |
+| `contents: write` | Committing/pushing badge updates and release tags (`push-badges`, `create-github-release`, reusable test/analyse workflows when `update_badges` is `true`) |
+| `checks: write` | Publishing test results (`test-code`) |
+
+Grant only what a given workflow actually exercises. The reusable `test-code-workflow.yml` and `prepare-release-workflow.yml` need `contents: write` and `checks: write` in addition to the permissions above.
 
 ## Available Actions
 

--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -18,20 +18,20 @@ runs:
   steps:
     - name: Commit updated Contents.m file
       shell: bash
-      continue-on-error: true
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-        git status
         find ${{ inputs.source_directory }} -type f -name Contents.m -exec git add {} +
-        git commit -m "Final check-ins for release v${{ inputs.version_number }} [skip actions]"
-        git fetch
-        git push
-        
+        if git diff --cached --quiet; then
+          echo "No Contents.m changes to commit"
+        else
+          git commit -m "Final check-ins for release v${{ inputs.version_number }} [skip actions]"
+          git fetch
+          git push
+        fi
+
     - name: Update tag
       shell: bash
-      if: always()
-      continue-on-error: true
       run: |
         git config user.name "github-actions[bot]"
         git config user.email "41898282+github-actions[bot]@users.noreply.github.com"

--- a/install-matbox/action.yml
+++ b/install-matbox/action.yml
@@ -3,7 +3,7 @@ description: 'Install MatBox in MATLAB on GitHub runner'
 inputs:
   mode:  # mode of installation: release or commit, i.e install a released version or use latest commit
     description: 'Which installation mode to use'
-    required: true
+    required: false
     default: 'release'
   version:
     description: 'MatBox version to install, e.g. "0.9.10". Only applies to release mode.'

--- a/install-matbox/installMatBox.m
+++ b/install-matbox/installMatBox.m
@@ -60,7 +60,7 @@ function [installPath, installMethod] = installFromRelease(version)
     end
 
     try
-        info = webread(releaseApiUrl);
+        info = webread(releaseApiUrl, githubWebOptions());
     catch ME
         if version ~= "latest"
             error("MatBox:Install:ReleaseNotFound", ...
@@ -73,6 +73,11 @@ function [installPath, installMethod] = installFromRelease(version)
 
     assetNames = {info.assets.name};
     isMltbx = startsWith(assetNames, 'MatBox');
+
+    numMatchingAssets = sum(isMltbx);
+    assert(numMatchingAssets == 1, ...
+        "MatBox:Install:AssetNotFound", ...
+        "Expected exactly one MatBox release asset but found %d.", numMatchingAssets)
 
     mltbx_URL = info.assets(isMltbx).browser_download_url;
 
@@ -126,4 +131,20 @@ function installPath = getMatBoxInstallPath()
     packageFolder = fileparts(installRequirementsFile);
     codeFolder = fileparts(packageFolder);
     installPath = string(fileparts(codeFolder));
+end
+
+function options = githubWebOptions()
+% githubWebOptions - weboptions carrying a GitHub auth header when available
+%
+%   On GitHub-hosted runners the runner IP is shared, so unauthenticated
+%   calls to the GitHub REST API (60 requests/hour per IP) can fail with a
+%   rate-limit error. Authenticating with the workflow token raises the
+%   limit to 5000 requests/hour. Falls back to unauthenticated access when
+%   GITHUB_TOKEN is not set, so local use keeps working.
+
+    options = weboptions();
+    token = string(getenv("GITHUB_TOKEN"));
+    if strlength(token) > 0
+        options.HeaderFields = ["Authorization", "Bearer " + token];
+    end
 end


### PR DESCRIPTION
## Summary

Addresses review findings that remained open on `main` after PRs #7/#8/#9.

- **Installer now authenticates to the GitHub API.** `installMatBox` called the GitHub REST API unauthenticated while the workflow token sat unused in the action env, risking rate-limit failures on shared runner IPs. Both release lookups (`latest` and pinned `tags/v*`) now attach `Authorization: Bearer $GITHUB_TOKEN` via a `githubWebOptions()` helper, falling back to unauthenticated access when the token is absent so local use keeps working.
- **Release action no longer swallows failures.** `create-github-release` used `continue-on-error` on the Contents.m commit and the tag step, so a rejected tag push silently released against a stale tag. The commit step now guards no-op changes with `git diff --cached --quiet`, and both steps fail loudly on real errors.
- **Asset-selection guard.** `installMatBox` asserts exactly one `MatBox*` release asset before dereferencing, replacing an opaque comma-list assignment error with a clear message.
- **`mode` input metadata.** Changed `required: true` → `required: false` to match its default.
- **README.** Added a required-permissions table (`contents`, `security-events`, `checks`) and aligned the example pins to `checkout@v6` / `setup-matlab@v3`.

## Verification

Static checks only — MATLAB Code Analyzer reports no issues and the edited action YAML parses. The auth and release-flow behavior is reasoned from the code, not exercised in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)