### PR TITLE
fix: parse MATLAB release names case-insensitively

### DIFF
--- a/configure-matlab-test-matrix/build_matrix.py
+++ b/configure-matlab-test-matrix/build_matrix.py
@@ -11,15 +11,19 @@ from pathlib import Path
 from typing import Any
 
 
-# Match MATLAB release names such as R2025a.
-RELEASE_PATTERN = re.compile(r"^R(?P<year>\d{4})(?P<half>[ab])$")
+# Match MATLAB release names such as R2025a. Case-insensitive: the MathWorks
+# "latest release" API returns a lowercase form (e.g. "r2026a") while
+# MLToolboxInfo.json and workflow inputs use the canonical "R2026a" form.
+RELEASE_PATTERN = re.compile(r"^R(?P<year>\d{4})(?P<half>[ab])$", re.IGNORECASE)
 
 
 def parse_release(release: str) -> tuple[int, str]:
     match = RELEASE_PATTERN.match(release)
     if not match:
         raise ValueError(f"Invalid MATLAB release: {release!r}")
-    return int(match.group("year")), match.group("half")
+    # Normalize the half to lowercase so callers can compare/sort tuples
+    # regardless of the input's case.
+    return int(match.group("year")), match.group("half").lower()
 
 
 def compare_releases(left: str, right: str) -> int:

--- a/configure-matlab-test-matrix/tests/test_build_matrix.py
+++ b/configure-matlab-test-matrix/tests/test_build_matrix.py
@@ -93,6 +93,17 @@ class BuildMatrixTest(unittest.TestCase):
 
         self.assertEqual(json.loads(outputs["matlab_versions"]), ["R2021a", "R2024a"])
 
+    def test_manual_versions_are_filtered_when_latest_release_is_lowercase(self):
+        # The MathWorks "latest release" API returns a lowercase release name
+        # (e.g. "r2026a"), unlike the canonical "R2026a" form used elsewhere.
+        outputs = self.run_builder(
+            "toolbox_range.json",
+            latest_release="r2024a",
+            matlab_versions='["R2020b", "R2021a", "R2024a", "R2024b"]',
+        )
+
+        self.assertEqual(json.loads(outputs["matlab_versions"]), ["R2021a", "R2024a"])
+
     def test_auto_versions_fail_when_toolbox_minimum_is_newer_than_latest(self):
         with self.assertRaisesRegex(ValueError, "No MATLAB versions to test"):
             self.run_builder("toolbox_range.json", latest_release="R2021b")
@@ -160,6 +171,17 @@ class BuildMatrixTest(unittest.TestCase):
             'matrix={"MATLABVersion":["R2022b","R2023a","R2023b","R2024a"]}',
             output_lines,
         )
+
+
+class ParseReleaseTest(unittest.TestCase):
+    def test_parse_release_is_case_insensitive(self):
+        self.assertEqual(build_matrix.parse_release("r2026a"), (2026, "a"))
+        self.assertEqual(build_matrix.parse_release("R2026A"), (2026, "a"))
+        self.assertEqual(build_matrix.parse_release("R2026a"), (2026, "a"))
+
+    def test_compare_releases_across_mixed_case(self):
+        self.assertEqual(build_matrix.compare_releases("r2026a", "R2025b"), 1)
+        self.assertEqual(build_matrix.compare_releases("R2025b", "r2026a"), -1)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

The smoke test's `prepare-release` pipeline crashed with:

```
ValueError: Invalid MATLAB release: 'r2026a'
```

Root cause: the MathWorks "latest release" API (`https://ssd.mathworks.com/supportfiles/ci/matlab-release/v0/latest`) returns a **lowercase** release name (`r2026a`), but `build_matrix.py`'s `RELEASE_PATTERN` required exact-case `R2026a`. The pytest fixtures never caught this because they use synthetic canonical-case strings — this is exactly the kind of gap the smoke test (against the real API) was built to catch.

Any caller that filters manual `matlab_versions` against the fetched latest release hits `filter_manual_matlab_versions` → `compare_releases` → `parse_release`, which raised uncaught. `matbox-actions-smoketest`'s `prepare-release.yml` (which passes `matlab_versions: '["R2024b"]'`) hit this on every run.

## Fix

- `RELEASE_PATTERN` now matches case-insensitively (`re.IGNORECASE`).
- `parse_release` normalizes the returned half-year letter to lowercase, so comparisons (`compare_releases`, sorting in `resolve_python_version`) stay correct regardless of input case.
- `generate_matlab_releases` already reconstructs output strings in canonical form (`f"R{year}a"`), so this only changes parsing — output version strings are unaffected.

## Tests

Added:
- `test_manual_versions_are_filtered_when_latest_release_is_lowercase` — reproduces the exact crash scenario (manual versions filtered against a lowercase `latest_release`).
- `test_parse_release_is_case_insensitive` / `test_compare_releases_across_mixed_case` — direct unit coverage on the fixed function.

All 16 tests pass (`python3 configure-matlab-test-matrix/tests/test_build_matrix.py -v`). Also reproduced the exact failing CLI invocation from the CI log locally and confirmed it now succeeds instead of crashing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)