### PR TITLE
fix: make MatBox release installs work in CI without degrading local installs

### DIFF
--- a/create-github-release/action.yml
+++ b/create-github-release/action.yml
@@ -61,7 +61,7 @@ runs:
     - name: Create GitHub release
       uses: ncipollo/release-action@v1
       with:
-        draft: true        
+        draft: true
         artifacts: "${{ inputs.mltbx_path }}"
         tag: "v${{ inputs.version_number }}"
         generateReleaseNotes: true

--- a/install-matbox/action.yml
+++ b/install-matbox/action.yml
@@ -12,13 +12,7 @@ inputs:
 runs:
   using: "composite"
   steps:
-      # Install and confirm in the same run-command step (the same -batch
-      # session). matlab-actions/run-command documents that MATLAB settings
-      # do not persist across separate -batch sessions ("use a single action"
-      # when a later step needs what an earlier one set up), so a fresh
-      # add-on install could appear to succeed here yet be invisible to a
-      # confirmation check made in a subsequent, separate step.
-      - name: Install and confirm MatBox
+      - name: Install MatBox
         uses: matlab-actions/run-command@v3
         env:
            GITHUB_TOKEN: ${{ github.token }}
@@ -26,5 +20,10 @@ runs:
           command: |
             addpath( "${{ github.action_path }}" )
             installMatBox( "${{ inputs.mode }}", "${{ runner.temp }}/matbox", "Version", "${{ inputs.version }}" )
+
+      - name: Confirm installation of MatBox
+        uses: matlab-actions/run-command@v3
+        with:
+          command: |
             versionStr = matbox.toolboxversion();
             assert(~isempty(versionStr), 'Failed to install MatBox.');

--- a/install-matbox/action.yml
+++ b/install-matbox/action.yml
@@ -12,7 +12,13 @@ inputs:
 runs:
   using: "composite"
   steps:
-      - name: Install MatBox
+      # Install and confirm in the same run-command step (the same -batch
+      # session). matlab-actions/run-command documents that MATLAB settings
+      # do not persist across separate -batch sessions ("use a single action"
+      # when a later step needs what an earlier one set up), so a fresh
+      # add-on install could appear to succeed here yet be invisible to a
+      # confirmation check made in a subsequent, separate step.
+      - name: Install and confirm MatBox
         uses: matlab-actions/run-command@v3
         env:
            GITHUB_TOKEN: ${{ github.token }}
@@ -20,10 +26,5 @@ runs:
           command: |
             addpath( "${{ github.action_path }}" )
             installMatBox( "${{ inputs.mode }}", "${{ runner.temp }}/matbox", "Version", "${{ inputs.version }}" )
-      
-      - name: Confirm installation of MatBox
-        uses: matlab-actions/run-command@v3
-        with:
-          command: |
             versionStr = matbox.toolboxversion();
             assert(~isempty(versionStr), 'Failed to install MatBox.');

--- a/install-matbox/installMatBox.m
+++ b/install-matbox/installMatBox.m
@@ -20,7 +20,7 @@ function [installPath, installMethod] = installMatBox(mode, installationFolder, 
     version = erase(options.Version, textBoundary("start") + "v");
 
     if mode == "release"
-        [installPath, installMethod] = installFromRelease(version); % local function
+        [installPath, installMethod] = installFromRelease(version, installationFolder); % local function
     elseif mode == "commit"
         if version ~= "latest"
             warning("MatBox:Install:VersionIgnored", ...
@@ -36,7 +36,7 @@ function [installPath, installMethod] = installMatBox(mode, installationFolder, 
     end
 end
 
-function [installPath, installMethod] = installFromRelease(version)
+function [installPath, installMethod] = installFromRelease(version, installationFolder)
     addonsTable = matlab.addons.installedAddons();
     isMatchedAddon = addonsTable.Name == "MatBox";
 
@@ -71,34 +71,28 @@ function [installPath, installMethod] = installFromRelease(version)
         end
     end
 
-    assetNames = {info.assets.name};
-    isMltbx = startsWith(assetNames, 'MatBox');
-
-    numMatchingAssets = sum(isMltbx);
-    assert(numMatchingAssets == 1, ...
-        "MatBox:Install:AssetNotFound", ...
-        "Expected exactly one MatBox release asset but found %d.", numMatchingAssets)
-
-    mltbx_URL = info.assets(isMltbx).browser_download_url;
-
-    % Download matbox
-    tempFilePath = websave(tempname, mltbx_URL);
-    cleanupObj = onCleanup(@(fp) delete(tempFilePath));
-
-    % Install toolbox. matlab.addons.install does not reliably enable a
-    % newly installed add-on under -batch (the mode matlab-actions/run-command
-    % uses), so enable it explicitly rather than assume install did.
-    matlab.addons.install(tempFilePath);
-    matlab.addons.enableAddon('MatBox')
-    rehash()
-    installPath = getMatBoxInstallPath();
-    installMethod = "mltbx";
+    % Install from the tagged source archive rather than the packaged .mltbx
+    % release asset. matlab.addons.install is not reliable under -batch (the
+    % mode matlab-actions/run-command always uses): MathWorks documents
+    % add-on installation via -batch as unsupported, and it has been observed
+    % to fail on some MATLAB releases (e.g. R2024b) while working on others
+    % (e.g. R2026a). The tagged archive uses the same addpath/savepath
+    % mechanism as commit-mode installs, which does not depend on -batch
+    % support for the Add-On Manager.
+    url = "https://github.com/ehennestad/MatBox/archive/refs/tags/" + string(info.tag_name) + ".zip";
+    [installPath, installMethod] = installFromArchive(url, installationFolder);
 end
 
 function [installPath, installMethod] = installFromCommit(installationFolder)
-
-    % Download latest zipped version of repo
     url = "https://github.com/ehennestad/MatBox/archive/refs/heads/main.zip";
+    [installPath, installMethod] = installFromArchive(url, installationFolder);
+end
+
+function [installPath, installMethod] = installFromArchive(url, installationFolder)
+% installFromArchive - Download a GitHub source archive (branch or tag) and
+% add its code folder to the path.
+
+    % Download the zipped source archive
     tempFilePath = websave(tempname, url);
     cleanupObj = onCleanup(@(fp) delete(tempFilePath));
 

--- a/install-matbox/installMatBox.m
+++ b/install-matbox/installMatBox.m
@@ -9,6 +9,13 @@ function [installPath, installMethod] = installMatBox(mode, installationFolder, 
 %   installMatBox("release", installationFolder, "Version", "0.9.10")
 %   installs a specific released version. Version only applies to release
 %   mode.
+%
+%   This file is the single source of truth for two contexts: the
+%   install-matbox CI action in this repository, and local installs by
+%   consumer toolboxes, which download this file at runtime (see
+%   matlab-toolbox-template's installMatBox bootstrap). Keep it a
+%   self-contained single file, and keep both the batch (CI) and
+%   interactive (local) install paths working.
 
     arguments
         mode (1,1) string {mustBeMember(mode, ["release", "commit"])} = "release"
@@ -71,16 +78,44 @@ function [installPath, installMethod] = installFromRelease(version, installation
         end
     end
 
-    % Install from the tagged source archive rather than the packaged .mltbx
-    % release asset. matlab.addons.install is not reliable under -batch (the
-    % mode matlab-actions/run-command always uses): MathWorks documents
-    % add-on installation via -batch as unsupported, and it has been observed
-    % to fail on some MATLAB releases (e.g. R2024b) while working on others
-    % (e.g. R2026a). The tagged archive uses the same addpath/savepath
-    % mechanism as commit-mode installs, which does not depend on -batch
-    % support for the Add-On Manager.
-    url = "https://github.com/ehennestad/MatBox/archive/refs/tags/" + string(info.tag_name) + ".zip";
-    [installPath, installMethod] = installFromArchive(url, installationFolder);
+    % Choose the install mechanism by session type. Under -batch (the mode
+    % matlab-actions/run-command always uses in CI), matlab.addons.install is
+    % documented by MathWorks as unsupported and has been observed to fail on
+    % some MATLAB releases (e.g. R2024b) while working on others (e.g.
+    % R2026a); install from the tagged source archive instead, using the same
+    % addpath/savepath mechanism as commit-mode installs. In interactive
+    % sessions, prefer the packaged .mltbx so MatBox is registered in the
+    % Add-On Manager (visible, version-tracked, uninstallable via GUI).
+    if batchStartupOptionUsed
+        url = "https://github.com/ehennestad/MatBox/archive/refs/tags/" + string(info.tag_name) + ".zip";
+        [installPath, installMethod] = installFromArchive(url, installationFolder);
+    else
+        [installPath, installMethod] = installFromMltbx(info);
+    end
+end
+
+function [installPath, installMethod] = installFromMltbx(releaseInfo)
+% installFromMltbx - Install the packaged .mltbx asset from a GitHub release.
+
+    assetNames = {releaseInfo.assets.name};
+    isMltbx = startsWith(assetNames, 'MatBox');
+
+    numMatchingAssets = sum(isMltbx);
+    assert(numMatchingAssets == 1, ...
+        "MatBox:Install:AssetNotFound", ...
+        "Expected exactly one MatBox release asset but found %d.", numMatchingAssets)
+
+    mltbx_URL = releaseInfo.assets(isMltbx).browser_download_url;
+
+    % Download matbox
+    tempFilePath = websave(tempname, mltbx_URL);
+    cleanupObj = onCleanup(@(fp) delete(tempFilePath));
+
+    % Install toolbox
+    matlab.addons.install(tempFilePath);
+    rehash()
+    installPath = getMatBoxInstallPath();
+    installMethod = "mltbx";
 end
 
 function [installPath, installMethod] = installFromCommit(installationFolder)

--- a/install-matbox/installMatBox.m
+++ b/install-matbox/installMatBox.m
@@ -85,8 +85,11 @@ function [installPath, installMethod] = installFromRelease(version)
     tempFilePath = websave(tempname, mltbx_URL);
     cleanupObj = onCleanup(@(fp) delete(tempFilePath));
 
-    % Install toolbox
+    % Install toolbox. matlab.addons.install does not reliably enable a
+    % newly installed add-on under -batch (the mode matlab-actions/run-command
+    % uses), so enable it explicitly rather than assume install did.
     matlab.addons.install(tempFilePath);
+    matlab.addons.enableAddon('MatBox')
     rehash()
     installPath = getMatBoxInstallPath();
     installMethod = "mltbx";


### PR DESCRIPTION
## Summary

The smoke test's release job failed at "Confirm installation of MatBox": `matbox.toolboxversion` was unresolved right after a fresh install reported success.

## Root cause (verified against CI history, not just docs)

| Workflow | MATLAB release | Install MatBox |
|---|---|---|
| Standalone `test-code` smoke workflow | `latest` → resolved to **R2026a** | ✅ succeeded, confirmed fine |
| Release pipeline's test job | pinned to **R2024b** | ❌ failed at the "Confirm installation" step |

Same code, different MATLAB release: `matlab.addons.install` under `-batch` (the mode `matlab-actions/run-command` always uses) is documented by MathWorks as unsupported, and empirically fails on R2024b while working on R2026a. Since the release-test matrix exists to validate against *older* supported releases, any consumer pinning an older MATLAB release could hit this.

Step-separation was ruled out as the cause: `commit` mode has long used `addpath`+`savepath()` across separate steps successfully (`savepath()` persists to disk; a new `-batch` session reads it at startup). An earlier commit on this branch merged install+confirm into one step on that mistaken premise and was reverted.

## Fix: pick the install mechanism by session type

`installMatBox.m` is the single source of truth for two contexts — this repo's CI action *and* local installs by consumer toolboxes, which download the file at runtime via matlab-toolbox-template's bootstrap. So the fix branches on `batchStartupOptionUsed` (builtin, R2019a+, verified present):

- **Batch sessions (CI):** install a specific or latest release from its tagged GitHub source archive (`archive/refs/tags/vX.Y.Z.zip`) using the same `addpath`/`savepath` mechanism `commit` mode already uses — no dependency on `matlab.addons.install` under `-batch`. Shared logic extracted into a local `installFromArchive` helper used by both release and commit paths.
- **Interactive sessions (local):** the packaged `.mltbx` via `matlab.addons.install` — the context MathWorks documents it for — so MatBox stays registered in the Add-On Manager (visible, version-tracked, uninstallable via GUI). This is the original install code restored unchanged.

The dual-context contract is now documented in the function help.

External contracts verified against the live GitHub API: the release payload's `tag_name` is v-prefixed (`v0.9.10`) and the constructed archive URL resolves (HTTP 200); the release carries exactly one `MatBox*.mltbx` asset, satisfying the mltbx branch's assert.

## Behavior notes

- `installMethod` for a fresh **batch** release install is now `"folder"` (was `"mltbx"`); interactive installs still report `"mltbx"`.
- The interactive branch cannot be exercised by CI (which is always `-batch`) — a known blind spot, mitigated by it being the long-working original code.

## Verification

MATLAB Code Analyzer clean; YAML parses; API contracts checked as above. The smoke test's next run against this branch is the real CI verification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)