### PR TITLE
fix: authenticate the release push with a token that can touch workflows

### DIFF
--- a/.github/workflows/_internal-prepare-release.yml
+++ b/.github/workflows/_internal-prepare-release.yml
@@ -10,6 +10,15 @@ name: Prepare release
 #
 # Publishing the draft is a human action, so it triggers
 # _internal-bump-major-tag, which moves the major tag onto the release commit.
+#
+# The release commit rewrites every workflow file under .github/workflows
+# (pin-internal-refs.sh). GitHub refuses to let the default GITHUB_TOKEN push
+# any commit touching .github/workflows, regardless of the permissions
+# declared below -- this is a hard restriction, not a config knob. Pushing
+# the tag therefore needs a token with the Workflows permission, which only a
+# PAT (or GitHub App token) can carry. RELEASE_TAG_TOKEN is a fine-grained
+# PAT scoped to this repo only, with Contents: Read and write and
+# Workflows: Read and write.
 
 on:
   workflow_dispatch:
@@ -31,6 +40,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           ref: main
+          token: ${{ secrets.RELEASE_TAG_TOKEN }}
 
       - name: Cut release
         env:


### PR DESCRIPTION
## Summary

Dispatching `Prepare release` for v1.5 failed pushing the tag:

```
! [remote rejected] v1.5 -> v1.5 (refusing to allow a GitHub App to create
or update workflow `.github/workflows/check-code-workflow.yml` without
`workflows` permission)
```

## Root cause

`scripts/prepare-release.sh`'s release commit rewrites every workflow file under `.github/workflows` (`pin-internal-refs.sh` pins internal action refs to the release tag — that's the entire point of the reproducibility model from #11). GitHub hard-blocks the default `GITHUB_TOKEN` from pushing any commit that touches `.github/workflows`, **regardless of the `permissions:` block declared in the workflow** — this isn't a config knob, it's a platform-level anti-privilege-escalation restriction. Only a PAT or GitHub App token carrying the **Workflows** permission can push such a commit.

## Fix

Added a `RELEASE_TAG_TOKEN` secret (a fine-grained PAT scoped to `ehennestad/matbox-actions` only, with **Contents: Read and write** and **Workflows: Read and write**) and used it as the `token:` for the checkout step, so the tag push inside `scripts/prepare-release.sh` authenticates with it. `gh release create` keeps using the default `GITHUB_TOKEN` — creating a release doesn't touch workflow files, so no elevated permission is needed there.

## Blast radius of the failed run

Confirmed clean: the tag push failed before completing, so the script's own rollback (`tagPushed` never got set) had nothing to delete, and `main` was never touched (the release commit is never merged there by design). No tag, no draft release, nothing to clean up.

## Setup required before this works

Create a fine-grained PAT scoped to `ehennestad/matbox-actions` only, with **Contents: Read and write** and **Workflows: Read and write**, and add it as the `RELEASE_TAG_TOKEN` secret in this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)