### PR TITLE
fix: authenticate the major-tag bump with a token that can touch workflows

### DIFF
--- a/.github/workflows/_internal-bump-major-tag.yml
+++ b/.github/workflows/_internal-bump-major-tag.yml
@@ -1,5 +1,14 @@
 name: Bump major tag
 
+# The major tag is force-moved onto the release commit, which has its
+# internal .github/workflows refs pinned to the release tag (see
+# scripts/pin-internal-refs.sh). GitHub refuses to let the default
+# GITHUB_TOKEN push any ref update that touches .github/workflows content,
+# regardless of the permissions declared below -- the same hard restriction
+# _internal-prepare-release.yml hits when pushing the release tag itself.
+# Reuse RELEASE_TAG_TOKEN (a fine-grained PAT scoped to this repo, with
+# Contents: Read and write and Workflows: Read and write) for the checkout.
+
 on:
   release:
     types: [published]
@@ -19,6 +28,7 @@ jobs:
         uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          token: ${{ secrets.RELEASE_TAG_TOKEN }}
 
       - name: Verify internal refs are pinned
         env:


### PR DESCRIPTION
## Summary

Publishing the v1.5 release failed to move the `v1` major tag:

```
! [remote rejected] v1 -> v1 (refusing to allow a GitHub App to create or
update workflow `.github/workflows/check-code-workflow.yml` without
`workflows` permission)
```

## Root cause

Same restriction #15 fixed for the release-tag push: the release commit has its internal `.github/workflows` refs pinned to the release tag (`scripts/pin-internal-refs.sh`), and GitHub hard-blocks the default `GITHUB_TOKEN` from pushing any ref update that touches `.github/workflows` content — regardless of the `permissions:` declared in the workflow. `_internal-bump-major-tag.yml`'s `git push origin "$major" --force` hit the identical wall, just on a different workflow (this one triggers on `release: published`, not `workflow_dispatch`).

## Fix

Reuse the existing `RELEASE_TAG_TOKEN` secret (already created for #15 — a fine-grained PAT scoped to this repo with Contents and Workflows read/write) as the checkout token here too, so the force-push authenticates with a credential that actually has the Workflows permission.

## Blast radius of the failed run

Clean: `git tag -f` only updates the local tag in the runner's throwaway checkout; the push was rejected before anything changed remotely, so `v1` is untouched at its prior commit. No manual cleanup needed — just re-publish (or re-trigger) once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)