### PR TITLE
ci: select a version bump type instead of typing a version number

### DIFF
--- a/.github/workflow-templates/prepare-release-modular.yml
+++ b/.github/workflow-templates/prepare-release-modular.yml
@@ -36,9 +36,18 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+' # Matches tags like v1.2.3
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version number in major.minor.patch format'
+      bump:
+        description: 'Version bump; the new version is inferred from the latest release tag'
         required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      version:
+        description: 'Explicit version override in major.minor.patch format; takes precedence over bump'
+        required: false
         type: string
 
 jobs:
@@ -47,6 +56,7 @@ jobs:
     uses: ehennestad/matbox-actions/.github/workflows/validate-version-job.yml@v1
     with:
       version: ${{ inputs.version }}
+      bump: ${{ inputs.bump }}
       ref_name: ${{ github.ref_name }}
 
   configure_test_matrix:

--- a/.github/workflow-templates/prepare-release.yml
+++ b/.github/workflow-templates/prepare-release.yml
@@ -6,9 +6,18 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+' # Matches tags like v1.2.3
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Version number in major.minor.patch format'
+      bump:
+        description: 'Version bump; the new version is inferred from the latest release tag'
         required: true
+        type: choice
+        options:
+          - patch
+          - minor
+          - major
+        default: patch
+      version:
+        description: 'Explicit version override in major.minor.patch format; takes precedence over bump'
+        required: false
         type: string
 
 jobs:
@@ -18,7 +27,10 @@ jobs:
     with:
       # Do not change
       version: ${{ inputs.version }}
-      
+
+      # Do not change
+      bump: ${{ inputs.bump }}
+
       # Do not change
       ref_name: ${{ github.ref_name }}
       

--- a/.github/workflows/_internal-prepare-release.yml
+++ b/.github/workflows/_internal-prepare-release.yml
@@ -23,9 +23,18 @@ name: Prepare release
 on:
   workflow_dispatch:
     inputs:
-      version:
-        description: 'Release version, MAJOR.MINOR or MAJOR.MINOR.PATCH (e.g. 1.5 or 1.5.1)'
+      bump:
+        description: 'Version bump; the new version is inferred from the latest release tag'
         required: true
+        type: choice
+        options:
+          - minor
+          - patch
+          - major
+        default: minor
+      version:
+        description: 'Explicit version override, MAJOR.MINOR or MAJOR.MINOR.PATCH (e.g. 1.5 or 1.5.1); takes precedence over bump'
+        required: false
         type: string
 
 permissions:
@@ -45,8 +54,9 @@ jobs:
       - name: Cut release
         env:
           GH_TOKEN: ${{ github.token }}
+          BUMP: ${{ inputs.bump }}
           VERSION: ${{ inputs.version }}
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          bash scripts/prepare-release.sh "$VERSION"
+          bash scripts/prepare-release.sh "${VERSION:-$BUMP}"

--- a/.github/workflows/prepare-release-workflow.yml
+++ b/.github/workflows/prepare-release-workflow.yml
@@ -11,6 +11,10 @@ on:
         type: string
         required: false
         description: 'Version number in major.minor.patch format (for manual triggers)'
+      bump:
+        type: string
+        required: false
+        description: "Bump type ('major', 'minor' or 'patch') used to infer the version from the latest release tag when no explicit version is given (for manual triggers)"
       ref_name:
         type: string
         required: false
@@ -59,6 +63,7 @@ jobs:
     uses: ehennestad/matbox-actions/.github/workflows/validate-version-job.yml@main
     with:
       version: ${{ inputs.version }}
+      bump: ${{ inputs.bump }}
       ref_name: ${{ inputs.ref_name }}
 
   configure_test_matrix:

--- a/.github/workflows/validate-version-job.yml
+++ b/.github/workflows/validate-version-job.yml
@@ -7,6 +7,10 @@ on:
         type: string
         required: false
         description: 'Version number in major.minor.patch format (for manual triggers)'
+      bump:
+        type: string
+        required: false
+        description: "Bump type ('major', 'minor' or 'patch') used to infer the version from the latest release tag when no explicit version is given (for manual triggers)"
       ref_name:
         type: string
         required: false
@@ -37,4 +41,5 @@ jobs:
         uses: ehennestad/matbox-actions/validate-version@main
         with:
           version: ${{ inputs.version }}
+          bump: ${{ inputs.bump }}
           ref_name: ${{ inputs.ref_name }}

--- a/scripts/prepare-release.sh
+++ b/scripts/prepare-release.sh
@@ -20,9 +20,14 @@
 # non-doc push to main dispatches a fresh smoke run, the latest result closely
 # tracks the current tip by the time a release is cut.
 #
-# Usage: scripts/prepare-release.sh <MAJOR.MINOR[.PATCH]>
-#   e.g. scripts/prepare-release.sh 1.5
-#        scripts/prepare-release.sh 1.5.1
+# Usage: scripts/prepare-release.sh <MAJOR.MINOR[.PATCH] | major | minor | patch>
+#   e.g. scripts/prepare-release.sh 1.5      # explicit version
+#        scripts/prepare-release.sh minor    # infer from the latest release tag
+#
+# With a bump keyword the new version is derived from the highest existing
+# vMAJOR.MINOR[.PATCH] tag: major -> (MAJOR+1).0, minor -> MAJOR.(MINOR+1),
+# patch -> MAJOR.MINOR.(PATCH+1). Major and minor releases keep the repo's
+# two-part tag convention; only patch releases carry a third component.
 set -euo pipefail
 
 smokeRepo="ehennestad/matbox-actions-smoketest"
@@ -58,16 +63,25 @@ check_smoke_workflow() {
 }
 
 if [ "$#" -ne 1 ]; then
-    echo "Usage: $0 <MAJOR.MINOR[.PATCH]>   e.g. $0 1.5" >&2
+    echo "Usage: $0 <MAJOR.MINOR[.PATCH] | major | minor | patch>   e.g. $0 1.5 or $0 minor" >&2
     exit 2
 fi
 
-version="$1"
-if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
-    echo "Error: version must be MAJOR.MINOR or MAJOR.MINOR.PATCH, e.g. 1.5 or 1.5.1" >&2
-    exit 2
-fi
-tag="v${version}"
+version=""
+bump=""
+case "$1" in
+    major|minor|patch)
+        bump="$1"
+        ;;
+    *)
+        version="$1"
+        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+(\.[0-9]+)?$ ]]; then
+            echo "Error: argument must be a version (MAJOR.MINOR or MAJOR.MINOR.PATCH, e.g. 1.5 or 1.5.1)" \
+                 "or one of: major, minor, patch" >&2
+            exit 2
+        fi
+        ;;
+esac
 
 scriptDir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 repoRoot="$(cd "${scriptDir}/.." && pwd)"
@@ -97,6 +111,26 @@ if [ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]; then
     echo "Error: local main is not in sync with origin/main." >&2
     exit 1
 fi
+
+# Resolve a bump keyword into a concrete version, now that all tags are
+# fetched. Pure major tags like v1 are floating aliases, so only full
+# vMAJOR.MINOR[.PATCH] release tags count as the latest release.
+if [ -n "$bump" ]; then
+    latestTag="$(git tag --list | grep -E '^v[0-9]+\.[0-9]+(\.[0-9]+)?$' | sort -V | tail -n 1 || true)"
+    if [ -z "$latestTag" ]; then
+        echo "Error: no existing vMAJOR.MINOR[.PATCH] tag to bump from. Pass an explicit version instead." >&2
+        exit 1
+    fi
+    IFS=. read -r latestMajor latestMinor latestPatch <<< "${latestTag#v}"
+    case "$bump" in
+        major) version="$((latestMajor + 1)).0" ;;
+        minor) version="${latestMajor}.$((latestMinor + 1))" ;;
+        patch) version="${latestMajor}.${latestMinor}.$((${latestPatch:-0} + 1))" ;;
+    esac
+    echo "Latest release tag is ${latestTag}; ${bump} bump gives version ${version}."
+fi
+tag="v${version}"
+
 if git rev-parse -q --verify "refs/tags/${tag}" >/dev/null || \
    git ls-remote --tags origin "$tag" | grep -q "refs/tags/${tag}$"; then
     echo "Error: tag ${tag} already exists." >&2

--- a/validate-version/action.yml
+++ b/validate-version/action.yml
@@ -5,6 +5,9 @@ inputs:
   version:
     description: 'Version number (for manual triggers)'
     required: false
+  bump:
+    description: "Bump type ('major', 'minor' or 'patch') used to infer the version from the latest release tag when no explicit version is given (for manual triggers)"
+    required: false
   ref_name:
     description: 'GitHub ref name (for tag triggers)'
     required: false
@@ -46,6 +49,8 @@ runs:
       id: set_version
       if: steps.check_skip_actions.outputs.skip_workflow != 'true'
       shell: bash
+      env:
+        INPUT_BUMP: ${{ inputs.bump }}
       run: |
         if [[ -n "${{ inputs.version }}" ]]; then
           # For manual trigger, use the input version
@@ -55,6 +60,26 @@ runs:
             echo "::error:: Input for 'version' ('$VERSION_NUMBER') is not in the expected major.minor.patch format."
             exit 1
           fi
+        elif [[ -n "$INPUT_BUMP" ]]; then
+          # For manual trigger with a bump type, infer the next version from
+          # the highest existing release tag. Requires a checkout that fetched
+          # tags (e.g. fetch-depth: 0).
+          if [[ ! "$INPUT_BUMP" =~ ^(major|minor|patch)$ ]]; then
+            echo "::error:: Input for 'bump' ('$INPUT_BUMP') must be one of: major, minor, patch."
+            exit 1
+          fi
+          LATEST_TAG=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1 || true)
+          if [[ -z "$LATEST_TAG" ]]; then
+            echo "::error:: No existing vMAJOR.MINOR.PATCH tag to bump from. Provide an explicit version instead."
+            exit 1
+          fi
+          IFS=. read -r MAJOR MINOR PATCH <<< "${LATEST_TAG#v}"
+          case "$INPUT_BUMP" in
+            major) VERSION_NUMBER="$((MAJOR + 1)).0.0" ;;
+            minor) VERSION_NUMBER="${MAJOR}.$((MINOR + 1)).0" ;;
+            patch) VERSION_NUMBER="${MAJOR}.${MINOR}.$((PATCH + 1))" ;;
+          esac
+          echo "Latest release tag is ${LATEST_TAG}; ${INPUT_BUMP} bump gives version ${VERSION_NUMBER}"
         else
           # For tag trigger, use the tag name
           TAG_NAME="${{ inputs.ref_name }}"


### PR DESCRIPTION
Cutting a release previously required typing an explicit version number on `workflow_dispatch`. This adds a major/minor/patch dropdown and infers the new version from the latest release tag, for both this repo's own release process and for consumers of the reusable workflows.

## Consumers

Both workflow templates now expose a `bump` dropdown (patch/minor/major, defaulting to patch), with `version` retained as an optional explicit override that takes precedence when set:

- `.github/workflow-templates/prepare-release.yml`
- `.github/workflow-templates/prepare-release-modular.yml`

The input threads through `prepare-release-workflow.yml` → `validate-version-job.yml` → the `validate-version` composite action, which does the inference: it takes the highest existing `vMAJOR.MINOR.PATCH` tag and bumps it (major → `X.0.0`, minor → `X.Y.0`, patch → `X.Y.Z+1`). This relies on the `fetch-depth: 0` checkout that `validate-version-job.yml` already performs. If no release tag exists yet, it fails with a message asking for an explicit version.

The tag-push trigger is unaffected — `inputs` is empty there, so the existing tag-name path still applies.

## This repo

`_internal-prepare-release.yml` gains the same dropdown (defaulting to minor), and `scripts/prepare-release.sh` accepts `major`/`minor`/`patch` as an alternative to a version argument so the inference also works when cutting a release locally. Inference happens after `git fetch --tags` and ignores floating major tags like `v1`, considering only full `vMAJOR.MINOR[.PATCH]` release tags.

Note the two schemes differ deliberately: matbox-actions uses two-part tags for major/minor releases (`v1.5`), so a major bump here gives `2.0`, whereas consumer toolboxes always carry three components and get `2.0.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)